### PR TITLE
Allow `now` to be passed as JS date instance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 8.2.0 - 2021-08-TBD
 
-### Changed
-- Allow `now` to be passed as a JS date instance.
+### Added
+- Allow `now` to be passed as a JS Date instance.
 
 ## 8.1.1 - 2021-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # http-signature-zcap-verify ChangeLog
 
+## 8.2.0 - 2021-08-TBD
+
+### Changed
+- Allow a JS date instance to be passed into `verifyCapabilityInvocation`.
+
 ## 8.1.1 - 2021-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 8.2.0 - 2021-08-TBD
 
 ### Changed
-- Allow a JS date instance to be passed into `verifyCapabilityInvocation`.
+- Allow `now` to be passed as a JS date instance.
 
 ## 8.1.1 - 2021-07-21
 

--- a/main.js
+++ b/main.js
@@ -50,6 +50,9 @@ export async function verifyCapabilityInvocation({
   expectedAction, inspectCapabilityChain, suite, additionalHeaders = [],
   allowTargetAttenuation = false, now = Math.floor(Date.now() / 1000)
 }) {
+  if(now instanceof Date) {
+    now = Math.floor(now.getTime() / 1000);
+  }
   if(!getInvokedCapability) {
     throw new TypeError(
       '"getInvokedCapability" must be given to dereference the ' +

--- a/main.js
+++ b/main.js
@@ -40,7 +40,8 @@ cryptoLd.use(Ed25519VerificationKey2020);
  * @param {boolean} [options.allowTargetAttenuation=false] - Allow the
  *   invocationTarget of a delegation chain to be increasingly restrictive
  *   based on a hierarchical RESTful URL structure.
- * @param {integer} [options.now=now] - A unix time stamp.
+ * @param {integer|Date} [options.now=now] - A unix time stamp or an
+ *   instance of Date.
  *
  * @returns {Promise<object>} The result of the verification.
 */

--- a/tests/10-verify.spec.js
+++ b/tests/10-verify.spec.js
@@ -153,7 +153,27 @@ describe('verifyCapabilityInvocation', function() {
         result.verified.should.be.an('boolean');
         result.verified.should.equal(true);
       });
-
+      it('should verify a valid request when "now" is a JS date instance',
+        async function() {
+          const now = new Date(Date.now());
+          const result = await verifyCapabilityInvocation({
+            url: invocationResourceUrl,
+            method,
+            suite,
+            headers: signed,
+            expectedHost,
+            getInvokedCapability,
+            documentLoader,
+            expectedTarget: invocationResourceUrl,
+            keyId,
+            now
+          });
+          should.exist(result);
+          result.should.be.an('object');
+          should.exist(result.verified);
+          result.verified.should.be.an('boolean');
+          result.verified.should.equal(true);
+        });
       it('should verify a valid request with multiple expectedHosts',
         async function() {
           const result = await verifyCapabilityInvocation({


### PR DESCRIPTION
Addresses issue #24 