### PR TITLE
Fix issue where `invocationTarget` was incorrect when query exists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @digitalbazaar/http-signature-zcap-verify ChangeLog
 
+## 11.1.1 - 2024-04-xx
+
+### Fixed
+- Fixed an issue where verification would fail if the url used to create the
+  `invocationTarget` when checking the proof contains a colon.
+
 ## 11.1.0 - 2022-11-13
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,7 +191,7 @@ export async function verifyCapabilityInvocation({
   });
   // invocation target must match absolute url
   let invocationTarget;
-  if(url.includes(':')) {
+  if(url.startsWith('https://')) {
     invocationTarget = url;
   } else {
     invocationTarget = `https://${headers.host}${url}`;


### PR DESCRIPTION
Fixes an issue where the `invocationTarget` could be incorrect if query params are in the url and contain a `:`.