### PR TITLE
Allow http protocol for target url.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -195,11 +195,13 @@ export async function verifyCapabilityInvocation({
   // because some applications allow and pass non-conformant
   // relative URLs with unencoded colons (and we accept those
   // because it is common to do so despite non-conformance)
-  if(url.startsWith('https://')) {
+  if(url.startsWith('https://') || url.startsWith('http://')) {
     invocationTarget = url;
   } else {
+    // If encountering a relative URL, assume HTTPS
     invocationTarget = `https://${headers.host}${url}`;
   }
+
   const capabilityAction = parsedInvocationHeader.params.action;
   const proof = {
     '@context': constants.ZCAP_CONTEXT_URL,


### PR DESCRIPTION
Partly addresses issue https://github.com/digitalbazaar/http-signature-zcap-verify/issues/36