### PR TITLE
verifyCapabilityInvocation no longer silently rewrites the invocationTarget to use a different uri scheme than options.url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -189,17 +189,7 @@ export async function verifyCapabilityInvocation({
     maxDelegationTtl,
     suite
   });
-  // invocation target must match absolute url
-  let invocationTarget;
-  // do not simply check for a colon (`:`) to find a relative URL
-  // because some applications allow and pass non-conformant
-  // relative URLs with unencoded colons (and we accept those
-  // because it is common to do so despite non-conformance)
-  if(url.startsWith('https://')) {
-    invocationTarget = url;
-  } else {
-    invocationTarget = `https://${headers.host}${url}`;
-  }
+  const invocationTarget = url
   const capabilityAction = parsedInvocationHeader.params.action;
   const proof = {
     '@context': constants.ZCAP_CONTEXT_URL,

--- a/lib/index.js
+++ b/lib/index.js
@@ -189,7 +189,17 @@ export async function verifyCapabilityInvocation({
     maxDelegationTtl,
     suite
   });
-  const invocationTarget = url
+  // invocation target must match absolute url
+  let invocationTarget;
+  // do not simply check for a colon (`:`) to find a relative URL
+  // because some applications allow and pass non-conformant
+  // relative URLs with unencoded colons (and we accept those
+  // because it is common to do so despite non-conformance)
+  if(url.includes(':')) {
+    invocationTarget = url;
+  } else {
+    invocationTarget = `https://${headers.host}${url}`;
+  }
   const capabilityAction = parsedInvocationHeader.params.action;
   const proof = {
     '@context': constants.ZCAP_CONTEXT_URL,


### PR DESCRIPTION
Note:
* after I realized I needed this, @dmitrizagidulin told me he'd also already had to make a similar change https://github.com/digitalbazaar/http-signature-zcap-verify/pull/38

Motivation:
* I ran into issues using this function e.g. when options.url is `http://localhost:8080`, e.g. in my dev environment.
* for a few months i've worked around this by rewriting localhost zcaps to use https just so they work with these DB libs. I tracked down the root cause to this, and verified that with this change, I can remove a ton of those workarounds e.g. in all my integration tests, which invoke zcaps with invocationTarget http://localhost:... (but until now had to actually sign https zcaps even though the real scheme was http)
* It seems like this function shouldn't be too opionionated about the invocationTarget, and should let the caller decide via options.url. the caller is in the best position to determine invocationTarget incl uri scheme
* add unit tests that would have failed before this change. before only a single invocationTarget variant was tested